### PR TITLE
뷰페이지 기능 구현

### DIFF
--- a/src/components/ClipboardCopy.js
+++ b/src/components/ClipboardCopy.js
@@ -1,0 +1,68 @@
+import styled from "styled-components";
+import { useState } from "react";
+
+const ClipboardCopy = ({ url }) => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  async function copyTextToClipboard(text) {
+    if ("clipboard" in navigator) {
+      // 사용 브라우저가 Clipboard API를 지원하는 경우
+      return await navigator.clipboard.writeText(text);
+    } else {
+      // 지원하지 않는 경우
+      return document.execCommand("copy", true, text);
+    }
+  }
+
+  const handleCopyClick = () => {
+    copyTextToClipboard(url)
+      .then(() => {
+        setIsCopied(true);
+        setTimeout(() => {
+          setIsCopied(false);
+        }, 1500);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  return (
+    <div>
+      <URLCopybox>
+        <input type="text" value={url} readOnly />
+        <CopyButton onClick={handleCopyClick}>
+          {isCopied ? "Copied!" : "Copy"}
+        </CopyButton>
+      </URLCopybox>
+    </div>
+  );
+};
+
+export default ClipboardCopy;
+
+const URLCopybox = styled.div`
+  border: solid 1px #8465e1;
+  border-radius: 4px;
+  height: 40px;
+  overflow: hidden;
+  input {
+    height: 100%;
+    padding: 11px;
+    width: calc(100% - 100px);
+    display: inline-block;
+    text-overflow: ellipsis;
+
+  }
+`;
+
+const CopyButton = styled.button`
+  float: right;
+  background-color: #8465e1;
+  color: #fff;
+  width: 74px;
+  height: 100%;
+  &:hover {
+    cursor: pointer;
+  }
+`;

--- a/src/components/Svg.js
+++ b/src/components/Svg.js
@@ -5,8 +5,8 @@ const ExternalLink = () => {
         height="15"
         viewBox="-2 -5 30 30"
         xmlns="http://www.w3.org/2000/svg"
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         >
             <path d="M14 4h-13v18h20v-11h1v12h-22v-20h14v1zm10 5h-1v-6.293l-11.646 11.647-.708-.708 11.647-11.646h-6.293v-1h8v8z" />
         </svg>

--- a/src/components/ViewCard.js
+++ b/src/components/ViewCard.js
@@ -1,8 +1,13 @@
 import styled from "styled-components"
-import { Link } from "react-router-dom";
 import ExternalLink from "./Svg";
+import { Button } from "../elements";
+import ClipboardCopy from "./ClipboardCopy";
+
 
 const ViewCard = ({ id, author, title, category, url, content, created_date,}) => {
+    console.log(created_date)
+    const dateTimeInKR = `${new Date(created_date).getFullYear()}년 ${new Date(created_date).getMonth()}월 ${new Date(created_date).getDay()}일`
+
     return (
         <Container>
             <header>
@@ -10,28 +15,23 @@ const ViewCard = ({ id, author, title, category, url, content, created_date,}) =
                 <Category>{category}</Category>
                 <Wrapper>
                     <span>{author}</span>&middot;
-                    <span>{created_date}</span>
+                    <span>{dateTimeInKR}</span>
                 </Wrapper>
             </header>
             <URLCopyBoxWrapper>
                 <h2>공유 URL</h2>
-                <URLCopybox>
-                    <input type="text" placeholder={url}/>
-                    <CopyButton>Copy</CopyButton>
-                </URLCopybox>
-                <Link to="#">
-                    <a>
-                        <ExternalLink />
-                        공유페이지 새창으로 열기
-                    </a>
-                </Link>
+                <ClipboardCopy url={url}/>
+                <a href={url} target="_blank">
+                    <ExternalLink />
+                    공유페이지 새창으로 열기
+                </a>
             </URLCopyBoxWrapper>
             <ContentWrapper>
                 <h2>공유하고 싶은 이유 or 상세정보</h2>
                 <Content>{content}</Content>
             </ContentWrapper>
             <ButtonContainer>
-                <EditButton>수정</EditButton>
+                <Button size="small">수정</Button>
                 <DeleteButton>삭제</DeleteButton>
             </ButtonContainer>
         </Container>
@@ -40,7 +40,7 @@ const ViewCard = ({ id, author, title, category, url, content, created_date,}) =
 
 export default ViewCard;
 
-const Container = styled.section`
+const Container = styled.article`
     padding: 3%;
 `
 
@@ -66,6 +66,7 @@ const Wrapper = styled.div`
 `
 
 const URLCopyBoxWrapper = styled.div`
+    overflow: hidden;
     h2 {
         margin-bottom: 11px;
         font-weight: 700;
@@ -73,7 +74,7 @@ const URLCopyBoxWrapper = styled.div`
     a {
         color: #FDB674;
         float: right;
-        margin-top: 4px;
+        margin-top: 7px;
         text-decoration: underline;
         font-size: 0.875rem;
         fill: #FDB674;
@@ -81,28 +82,6 @@ const URLCopyBoxWrapper = styled.div`
     }
     svg {
         vertical-align: bottom;
-    }
-`
-
-const URLCopybox = styled.div`
-    border: solid 1px #8465E1;
-    border-radius: 4px;
-    height: 40px;
-    overflow: hidden;
-    input {
-        height: 100%;
-        padding: 11px;
-        box-sizing: border-box;
-    }
-`
-
-const CopyButton = styled.button`
-    float: right;
-    background-color: #8465E1;
-    color: #fff;
-    padding: 11px 21px;
-    &:hover {
-        cursor: pointer;
     }
 `
 
@@ -116,24 +95,16 @@ const ContentWrapper = styled.div`
 
 const Content = styled.p`
     min-height: 100px;
-    max-height: 300px;
+    max-height: 25vh;
     overflow: scroll;
     overflow-x: hidden;
     line-height: 20px;
 `
 
 const ButtonContainer = styled.div`
-    margin-top: 72px;
+    margin-top: 50px;
     display: flex;
     justify-content: flex-end;
-`
-
-const EditButton = styled.button`
-    border: solid 1px #8465E1;
-    background-color: #8465E1;
-    color: #fff;
-    padding: 5px 23px;
-    border-radius: 4px;
 `
 
 const DeleteButton = styled.button`

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -1,11 +1,12 @@
 import ViewCard from "../components/ViewCard";
 
 const ViewPage = ({dataList}) => {
-  return (
+
+    const data = dataList[0];
+
+    return (
     <div>
-      {dataList.map((it) => {
-        return <ViewCard {...it} />;
-      })}
+        <ViewCard {...data} />
     </div>
   );
 };


### PR DESCRIPTION
#20 뷰페이지 기능 구현 완료
#### 1. URL 클립보드 copy 기능 구현
- ClipboardCopy 컴포넌트로 구현
- Copy 버튼을 누르면 url이 클립보드로 copy가 되고 버튼에 `Copied!` 라는 문구가 표시됩니다.
- `Copied!` 문구는 일정 시간이 지나면 다시 `Copy` 문구로 바뀝니다.
#### 2. 공유페이지 새창 열기 기능 구현
#### 3. 작성일시 `YYYY년 MM월 DD일` 로 표시
#### 4. URL 주소가 길 경우 ellipsis 처리
![image](https://user-images.githubusercontent.com/74545780/155724783-7a0d7a73-f669-4ad3-9103-3b09c92a7186.png)
#### 5. [질문] 게시글 본문 내용 height 건
게시글 본문 영역의 height값을 `vh` 단위를 써서 유동적으로 적용되게끔 했는데 그래도 맨 아래의 수정,삭제 버튼이 잘려서 나오는 경우가 있습니다ㅠ 이런 경우는 height값을 어떻게 주어야 모바일 화면에서 버튼이 잘리지 않고 잘 나올수 있게 할수있을까요?
![image](https://user-images.githubusercontent.com/74545780/155725469-2b7e1df2-da8b-4ad8-9c0a-0e372c1e4f7d.png)

게시글 본문 영역의 css 속성은 아래와 같이 줬습니다.
```js 
const Content = styled.p`
    min-height: 100px;
    max-height: 25vh;
    overflow: scroll;
    overflow-x: hidden;
    line-height: 20px;
`
```
