### PR TITLE
ListItem 스타일 추가 및 카테고리태그 스타일 컴포넌트화

### DIFF
--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -38,8 +38,12 @@ const ItemList = styled.div`
   justify-content: space-between;
   padding: 0.5em 1em;
   font-size: 14px;
-  margin-top: 10px;
-
+  margin: 10px 9px 0;
+  border-radius: 10px;
+  height: 68px;
+  align-items: center;
+  box-sizing: border-box;
+  overflow: hidden;
   .bold {
     font-weight: 500;
     font-size: 16px;
@@ -66,18 +70,20 @@ const Category = styled.div`
 
 const Contents = styled.div`
   flex: 6;
-  margin: 0 1em;
-  padding-top: 0.5em;
-
+  margin-left: 1em;
+  max-height: 40px;
+  overflow: hidden;
+  white-space: nowrap;
   .cont {
-    margin: 0.5em 0 0 0;
-    color: #999999;
+      margin-top: 0.5em;
+      color: #999999;
+      max-height: 0.875rem;
+      text-overflow: ellipsis;
   }
 
 `
 const Info = styled.div`
   flex: 2;
-  padding-top: 0.5em;
   text-align: right;
 
   .day {

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { CategoryTag } from '../elements';
 import {timeForToday} from "../Util/timeForToday";
 
 
@@ -8,9 +9,9 @@ const ListItem = (props) => {
 
   return (
       <ItemList key={id} onClick={_onClick}>
-        <Category>
+        <CategoryTag category={category} type="square">
           <p className='catType'>{category}</p>
-        </Category>
+        </CategoryTag>
         <Contents>
           <dl>
             <dt className='bold'>{title}</dt>
@@ -59,7 +60,7 @@ const Category = styled.div`
   .catType {
     width: 50px;
     background-color: #D7F5F5;
-    margin: 0 auto;
+    /* margin: 0 auto; */
     line-height: 50px;
     border-radius: 10px;
     box-sizing: border-box;

--- a/src/elements/CategoryTag.js
+++ b/src/elements/CategoryTag.js
@@ -1,39 +1,77 @@
 import React from 'react';
-import styled from "styled-components";
+import styled, {css} from "styled-components";
+
+const types = {
+    square: {
+        lineHeight: '3.13rem',
+        fontSize: '0.875rem',
+        borderRadius: "8px",
+        marginBottom: "0",
+        minWidth: "3.13rem",
+        height: "3.13rem",
+    },
+    long: {
+        lineHeight: '1.81rem',
+        fontSize: '1rem',
+        borderRadius: "15px",
+        marginBottom: "24px",
+        minWidth: "4.31rem",
+        height: "1.81rem",
+    }
+}
+
+const typeStyles = css`
+    ${({type}) => css`
+        line-height: ${types[type].lineHeight};
+        font-size: ${types[type].fontSize};
+        border-radius: ${types[type].borderRadius};
+        margin-bottom: ${types[type].marginBottom};
+        min-width: ${types[type].minWidth};
+        height: ${types[type].height};
+    `}
+`
+
+const Tag = styled.p`
+    display: inline-block;
+    text-align: center;
+    border: none;
+    box-sizing: border-box;
+    font-weight: 700;
+    color: #000;
+    background-color: ${(props) => props.tagColor};
+    ${typeStyles}
+`
 
 const CategoryTag = (props) => {
-    const {children, category} = props;
-    let tagColor = "";
+    const {children, category, type} = props;
+    const styles = {type: type};
 
-    if(category === "HTML"){
-        tagColor = "#EBE1F6";
-    } else if (category === "CSS"){
-        tagColor = "#D7F5F5"
-    } else if (category === "JS"){
-        tagColor = "#F9E79F"
-    } else if (category === "React") {
-        tagColor = "#5ED3F3"
-    } else { // 기타
-        tagColor = "#D6DBDF"
+    let tagColor = "";
+    switch(category){
+        case "HTML" :
+            tagColor = "#EBE1F6";
+            break;
+        case "CSS" :
+            tagColor = "#D7F5F5";
+            break;
+        case "JS" :
+            tagColor = "#F9E79F";
+            break;
+        case "React" :
+            tagColor = "#5ED3F3";
+            break;
+        default : // 기타
+            tagColor = "#D6DBDF";
+            break;
     }
 
   return (
-    <Tag tagColor={tagColor}>
+    <Tag tagColor={tagColor} {...styles}>
       {children}
     </Tag>
   );
 };
 
-const Tag = styled.p`
-    display: inline-block;
-    font-size: 1rem;
-    border: none;
-    border-radius: 15px;
-    padding: 3px 12px;
-    margin-bottom: 24px;
-    background-color: ${(props) => props.tagColor};
-    color: #000;
-    font-weight: 500;
-`
+
 
 export default CategoryTag;

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -24,7 +24,7 @@ const ViewPage = () => {
       <Container>
         <header>
           <Title>{techInfo_list[techInfo_index] ? techInfo_list[techInfo_index].title : ""}</Title>
-          <CategoryTag category={techInfo_list[techInfo_index].category}>{techInfo_list[techInfo_index].category}</CategoryTag>
+          <CategoryTag category={techInfo_list[techInfo_index].category} type="long">{techInfo_list[techInfo_index].category}</CategoryTag>
           <Wrapper>
             <span>{techInfo_list[techInfo_index].author}</span>&middot;
             <span>{dateTimeInKR}</span>


### PR DESCRIPTION
#35 
- border-raidus 등의 약간의 스타일 추가
- ListItem의 카테고리태그를 category 값에 따라 색상이 다르게 표시되도록 CategoryTag 스타일 컴포넌트 수정
  - 페이지에 따라 모양이 달라지는 것을 적용시키기 위해 `type` prop을 추가하였습니다. 
```html
<!-- ViewPage에서의 사용-->
<CategoryTag type="long">HTML</CategoryTag>

<!-- ListItem에서의 사용-->
<CategoryTag type="square">HTML</CategoryTag>

```
- ListItem에서 content 내용은 한줄만 표시되도록 수정(ellipsis 효과는 아직 적용되지 않았습니다.)
 
![image](https://user-images.githubusercontent.com/74545780/156777166-ce6c8fa5-ef4f-41f5-ab97-3b7acba8e793.png)

