### PR TITLE
listItem 등록최신순 정렬 및 뷰페이지 content 개행 문제 해결

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -55,11 +55,7 @@ const Home = () => {
   return (
     <div>
       <ListOptionGroup addChecked={addChecked} removeChecked={removeChecked}/>
-      {techInfo_list.sort((a,b) => {
-          if(a.created_date > b.created_date){
-              return -1;
-          }
-      }).map((it, index) => {
+      {techInfo_list.sort((a,b) => b.created_date-a.created_date).map((it, index) => {
         return (
           <ListItem key={it.id} {...it} _onClick={() => {
             navigate('/view/' + index)

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -10,7 +10,7 @@ const Home = () => {
   const dispatch = useDispatch();
 
   const techInfo_list = useSelector((state) => state.techInfo.list);
-
+  
   const [authorChecked, setAuthorChecked] = useState([]);
   const [catChecked, setCatChecked] = useState([]);
 
@@ -55,7 +55,11 @@ const Home = () => {
   return (
     <div>
       <ListOptionGroup addChecked={addChecked} removeChecked={removeChecked}/>
-      {techInfo_list.map((it, index) => {
+      {techInfo_list.sort((a,b) => {
+          if(a.created_date > b.created_date){
+              return -1;
+          }
+      }).map((it, index) => {
         return (
           <ListItem key={it.id} {...it} _onClick={() => {
             navigate('/view/' + index)

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -14,6 +14,11 @@ const ViewPage = () => {
   const params = useParams();
   const techInfo_index = params.index;
   const techInfo_list = useSelector((state) => state.techInfo.list);
+
+  // 본문 개행 처리를 위한 배열 생성
+  const contentLines = techInfo_list[techInfo_index].content.split("\n")
+
+  // 작성일시 표시
   const timeData = new Date(techInfo_list[techInfo_index].created_date);
   const year = timeData.getFullYear();
   const month = timeData.getMonth() + 1;
@@ -67,7 +72,13 @@ const ViewPage = () => {
         </URLCopyBoxWrapper>
         <ContentWrapper>
           <h2>공유하고 싶은 이유 or 상세정보</h2>
-          <Content>{techInfo_list[techInfo_index].content}</Content>
+          <Content>{
+              contentLines.map((line, idx) => {
+                  return (
+                      <li key={idx}>{line}</li>
+                )
+            })
+          }</Content>
         </ContentWrapper>
         <ButtonContainer>
           <Button size="small" _onClick={() => {navigate('/edit/' + techInfo_index)}}>수정</Button>


### PR DESCRIPTION
#47 (1/2) ✅
#59 ✅

### 1. listItem 등록최신순 정렬
### 2. 뷰페이지 개행 문제 해결
- **이슈**
새 글 등록시 서버에는 개행 문자 포함하여 잘 저장이 되는데 조회페이지에 데이터를 뿌려줄때는 개행이 되지 않고 한줄로 나오는 이슈 발생

|![image](https://user-images.githubusercontent.com/74545780/157643830-cd67a1ad-57f8-454b-a50a-6571e379edab.png)|
|:--:|
|![image](https://user-images.githubusercontent.com/74545780/157643678-5f04d3bf-3210-4398-9f81-00aee682ab1b.png)|



- **해결**
content 값의 개행 문자 `\n`을 기준으로 split하여 배열 생성 후 각 요소를 li 태그로 렌더링하는 방식을 사용하였습니다

|![image](https://user-images.githubusercontent.com/74545780/157644354-90a24ae2-2556-4db0-b3da-6a8e269db993.png)|
|:--:|
|![image](https://user-images.githubusercontent.com/74545780/157644366-fe28291b-0686-4511-a908-c322ddbe97ab.png)|